### PR TITLE
chore(Dockerfile): bump kind base img to 1.22.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM kindest/node:v1.20.2
+FROM kindest/node:v1.22.2
 
 RUN apt-get update && apt-get install -y nfs-kernel-server


### PR DESCRIPTION
* Bumps the kind base image to latest [v1.22.2](https://hub.docker.com/r/kindest/node/tags)
